### PR TITLE
Shader Rendering Fails in Stereoscopic (Single-pass) render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,38 +1,42 @@
 # Changelog
 
+## [<to-be-released>] - 2024-10-02
+
+- Fixes Post-processing shaders in Single-pass instanced rendering for stereo VR.
+
 ## [0.2.0] - 2024-09-27
 
-* Mostly code cleanup and minor fixes regarding compatibility through different versions from 2022 to Unity 6. Tested with no warnings or errors in 2022.3.47f1, 2023.1.20f1, 2023.2.20f1 and 6000.0.18f1. Removed code referencing to a 2023.3 beta version which ultimately became Unity 6, so this package should not work any longer with 2023.3 beta versions : just upgrade to Unity 6.
+- Mostly code cleanup and minor fixes regarding compatibility through different versions from 2022 to Unity 6. Tested with no warnings or errors in 2022.3.47f1, 2023.1.20f1, 2023.2.20f1 and 6000.0.18f1. Removed code referencing to a 2023.3 beta version which ultimately became Unity 6, so this package should not work any longer with 2023.3 beta versions : just upgrade to Unity 6.
 
 ## [0.1.7] - 2024-09-22
 
-* Fix bug introduced in 0.1.6 that disabled the volumetric fog when it should not. 
+- Fix bug introduced in 0.1.6 that disabled the volumetric fog when it should not.
 
 ## [0.1.6] - 2024-09-22
 
-* Now the main light computations will be skipped when its volume scattering parameter is set to 0. The same will happen with additional lights and their scattering parameter. Slightly changed the falloff of the volume parameter "Additional Light Radius". 
+- Now the main light computations will be skipped when its volume scattering parameter is set to 0. The same will happen with additional lights and their scattering parameter. Slightly changed the falloff of the volume parameter "Additional Light Radius".
 
 ## [0.1.5] - 2024-08-10
 
-* Increased the number of maximum steps that can be tweaked through the volume from 128 to 256.
+- Increased the number of maximum steps that can be tweaked through the volume from 128 to 256.
 
 ## [0.1.4] - 2024-07-26
 
-* Removed some text and comments.
+- Removed some text and comments.
 
 ## [0.1.3] - 2024-07-07
 
-* Updated some texts referencing old Unity 2023.3 beta to replace them by Unity 6 to make it clear that this package should work on Unity 6. Tested in Unity 6000.0.9f1. 
-* No other functional changes were made.
+- Updated some texts referencing old Unity 2023.3 beta to replace them by Unity 6 to make it clear that this package should work on Unity 6. Tested in Unity 6000.0.9f1.
+- No other functional changes were made.
 
 ## [0.1.2] - 2024-02-12
 
-* Fixed potential issue with Unity version check in shader.
+- Fixed potential issue with Unity version check in shader.
 
 ## [0.1.1] - 2024-02-01
 
-* Fixed non matching blur iterations in render graph and non render graph paths. Cleanup typos and unused attribute.
+- Fixed non matching blur iterations in render graph and non render graph paths. Cleanup typos and unused attribute.
 
 ## [0.1.0] - 2024-01-28
 
-* Initial Release. Verified in Unity 2022.3.18f1, 2023.2.7f1 and 2023.3.0b4.
+- Initial Release. Verified in Unity 2022.3.18f1, 2023.2.7f1 and 2023.3.0b4.

--- a/Shaders/DownsampleDepth.shader
+++ b/Shaders/DownsampleDepth.shader
@@ -31,6 +31,8 @@ Shader "Hidden/DownsampleDepth"
 
             float Frag(Varyings input) : SV_Target
             {
+
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
                 float4 depths = GATHER_RED_TEXTURE2D_X(_CameraDepthTexture, sampler_CameraDepthTexture, input.texcoord);
 
                 float minDepth = Min3(depths.x, depths.y, min(depths.z, depths.w));

--- a/Shaders/VolumetricFog.shader
+++ b/Shaders/VolumetricFog.shader
@@ -210,6 +210,7 @@ Shader "Hidden/VolumetricFog"
 
             float4 Frag(Varyings input) : SV_Target
             {
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
                 return DepthAwareGaussianBlur(input.texcoord, float2(1.0, 0.0), _BlitTexture, sampler_LinearClamp, _BlitTexture_TexelSize.xy);
             }
 
@@ -240,6 +241,7 @@ Shader "Hidden/VolumetricFog"
 
             float4 Frag(Varyings input) : SV_Target
             {
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
                 return DepthAwareGaussianBlur(input.texcoord, float2(0.0, 1.0), _BlitTexture, sampler_LinearClamp, _BlitTexture_TexelSize.xy);
             }
 
@@ -270,6 +272,8 @@ Shader "Hidden/VolumetricFog"
 
             float4 Frag(Varyings input) : SV_Target
             {
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+
                 // get the full resolution depth and convert it to linear eye depth
                 float fullResDepth = LoadSceneDepth(input.positionCS.xy);
                 float linearFullResDepth = LinearEyeDepth(fullResDepth, _ZBufferParams);


### PR DESCRIPTION
The Scriptable Render Feature does not work as expected  in stereoscopic setups (e.g., VR, HMD). Specifically, the same texture is applied to both the left and right cameras. This behavior likely stems from missing directives necessary for proper texture mapping in stereoscopic mode.

## Expected Behavior
Textures should be rendered correctly for each eye, providing a distinct visual experience without overlapping textures.

## How to reproduce

- Unity 2022.3.20f1.
- OpenXR with URP renderer.
- Set up the Volumetric Light feature.
- Observe the texture application in a stereoscopic view.

## Fix
Although the official [documentation](https://docs.unity3d.com/Manual/SinglePassInstancing.html) is a bit dated, I noticed while reviewing the shaders that several fragment shaders were missing the call to `UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);`. Adding these calls resolves the issue and restores the expected behavior.

