### PR TITLE
Fix: When visible light count is higher the max visible additional light

### DIFF
--- a/Runtime/VolumetricFogRenderPass.cs
+++ b/Runtime/VolumetricFogRenderPass.cs
@@ -393,7 +393,7 @@ public sealed class VolumetricFogRenderPass : ScriptableRenderPass
 		{
 			int additionalLightIndex = 0;
 
-			for (int i = 0; i < visibleLights.Length; ++i)
+			for (int i = 0; i < Mathf.Min (visibleLights.Length, UniversalRenderPipeline.maxVisibleAdditionalLights); ++i)
 			{
 				if (i == mainLightIndex)
 					continue;


### PR DESCRIPTION
We have been experiencing when we have many lights on the scene, we got an Index is out of range in this line:
    Anisotropies[additionalLightIndex] = anisotropy;

because additional Light index was higher than UniversalRenderPipeline.maxVisibleAdditionalLights.
When this happens, whole rendering is frozen. This is an hot fix for that.