### PR TITLE
Fixed graphicFormat for upsampleCompositionPass.

### DIFF
--- a/Runtime/VolumetricFogRenderPass.cs
+++ b/Runtime/VolumetricFogRenderPass.cs
@@ -196,6 +196,7 @@ public sealed class VolumetricFogRenderPass : ScriptableRenderPass
 		cameraTargetDescriptor.width = originalResolution.x;
 		cameraTargetDescriptor.height = originalResolution.y;
 		cameraTargetDescriptor.colorFormat = originalColorFormat;
+		cameraTargetDescriptor.graphicsFormat = renderingData.cameraData.cameraTargetDescriptor.graphicsFormat;
 		ReAllocateIfNeeded(ref volumetricFogUpsampleCompositionRTHandle, cameraTargetDescriptor, wrapMode: TextureWrapMode.Clamp, name: VolumetricFogUpsampleCompositionRTName);
 	}
 
@@ -473,6 +474,7 @@ public sealed class VolumetricFogRenderPass : ScriptableRenderPass
 		cameraTargetDescriptor.width = originalResolution.x;
 		cameraTargetDescriptor.height = originalResolution.y;
 		cameraTargetDescriptor.colorFormat = originalColorFormat;
+		cameraTargetDescriptor.graphicsFormat = cameraData.cameraTargetDescriptor.graphicsFormat;
 		volumetricFogUpsampleCompositionTarget = UniversalRenderer.CreateRenderGraphTexture(renderGraph, cameraTargetDescriptor, VolumetricFogUpsampleCompositionRTName, false);
 	}
 


### PR DESCRIPTION
Fixed a mach band issue reported at:
https://github.com/CristianQiu/Unity-URP-Volumetric-Light/issues/42

Tested in Unity 6000.5.4f1 and URP 17.5.0.
I also added the same fix for older version of URP (OnCameraSetup) but haven't tested.